### PR TITLE
fix: remove stale popstate listener instead of leaking a new one

### DIFF
--- a/src/classes/remote-dialog.ts
+++ b/src/classes/remote-dialog.ts
@@ -20,6 +20,9 @@ export class RemoteDialog extends LitElement {
 	fadedInTimer?: ReturnType<typeof setTimeout> = undefined;
 	tabIndex = -1;
 
+
+	onPopState = () => this.closeDialog();
+
 	showDialog(config: IAction) {
 		this.config = config;
 		this.open = true;
@@ -35,7 +38,7 @@ export class RemoteDialog extends LitElement {
 				dialog.close();
 				dialog.showModal();
 			}
-			window.addEventListener('popstate', () => this.closeDialog());
+			window.addEventListener('popstate', this.onPopState);
 		}
 	}
 
@@ -54,7 +57,7 @@ export class RemoteDialog extends LitElement {
 					dialog.showModal();
 					dialog.close();
 				}
-				window.removeEventListener('popstate', () => this.closeDialog());
+				window.removeEventListener('popstate', this.onPopState);
 			}, 140);
 		}
 	}


### PR DESCRIPTION
Each time the dialog opens, it adds a new popstate listener, but it never removes it because it uses a different function reference. This causes unused listeners to build up over time. The fix stores the listener in one place and reuses the same reference when adding and removing it.