### PR TITLE
fix: return early in querySelectorAsync when element already exists

### DIFF
--- a/src/utils/querySelectorAsync.ts
+++ b/src/utils/querySelectorAsync.ts
@@ -7,6 +7,7 @@ export async function querySelectorAsync(
 		const element = parent.querySelector(selector);
 		if (element) {
 			resolve(element);
+			return;
 		}
 
 		const rejectTimeout = setTimeout(


### PR DESCRIPTION
When the element already exists, the function finds it but still creates a timer and a MutationObserver that are never cleaned up. Τhis happens every time the dialog opens and causes unnecessary timers and observers to build up. The fix simply returns immediately after finding the element.